### PR TITLE
Added "Attached Cards" display to Card hover UI

### DIFF
--- a/Scenes/board.tscn
+++ b/Scenes/board.tscn
@@ -43,7 +43,7 @@ anchors_preset = -1
 offset_left = 10.0
 offset_top = 449.0
 offset_right = 312.0
-offset_bottom = 1064.0
+offset_bottom = 958.0
 
 [node name="CardText" type="Label" parent="CanvasLayer/Info/ScrollContainer"]
 custom_minimum_size = Vector2(302, 615)
@@ -51,6 +51,52 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 autowrap_mode = 1
+
+[node name="AttachedCardsBackground" type="ColorRect" parent="CanvasLayer/Info"]
+layout_mode = 2
+offset_left = 10.0
+offset_top = 967.0
+offset_right = 312.0
+offset_bottom = 1066.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+color = Color(0.18359, 0.18359, 0.18359, 1)
+
+[node name="AttachedCardsList" type="ScrollContainer" parent="CanvasLayer/Info"]
+layout_direction = 2
+layout_mode = 0
+offset_left = 14.0
+offset_top = 971.0
+offset_right = 308.0
+offset_bottom = 1062.0
+vertical_scroll_mode = 0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="CanvasLayer/Info/AttachedCardsList"]
+clip_contents = true
+layout_direction = 2
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="AttachedCardsLabel" type="Node2D" parent="CanvasLayer/Info"]
+
+[node name="ColorRect" type="ColorRect" parent="CanvasLayer/Info/AttachedCardsLabel"]
+offset_left = 200.0
+offset_top = 967.0
+offset_right = 312.0
+offset_bottom = 990.0
+color = Color(0.117647, 0.117647, 0.117647, 0.337255)
+
+[node name="Label" type="Label" parent="CanvasLayer/Info/AttachedCardsLabel"]
+offset_left = 200.0
+offset_top = 967.0
+offset_right = 312.0
+offset_bottom = 990.0
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 3
+theme_override_font_sizes/font_size = 15
+text = "Attached Cards"
+horizontal_alignment = 2
 
 [node name="Host" type="Button" parent="CanvasLayer"]
 visible = false

--- a/Scripts/Multiplayer.gd
+++ b/Scripts/Multiplayer.gd
@@ -310,13 +310,30 @@ func _on_list_exit():
 	$Camera2D.canGo = true
 
 
-func update_info(card_num, desc, art_data):
+func prepare_attached_card_for_display(card_texture):
+	var ac_img = TextureRect.new()
+	ac_img.texture = card_texture
+	ac_img.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	ac_img.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT
+	ac_img.custom_minimum_size = Vector2(66, 91)
+	return ac_img
+
+
+func update_info(card_num, desc, art_data, attached_cards):
 	$CanvasLayer/Info/Preview.texture = art_data
 	$CanvasLayer/Info/ScrollContainer/CardText.text = desc
+	for ac in $CanvasLayer/Info/AttachedCardsList/HBoxContainer.get_children():
+		ac.free()  # free cards if there are any in here still somehow
+	for attached_card_texture in attached_cards:
+		# print(attached_card)
+		var ac_img = prepare_attached_card_for_display(attached_card_texture)
+		$CanvasLayer/Info/AttachedCardsList/HBoxContainer.add_child(ac_img)
 
 func clear_info():
 	$CanvasLayer/Info/Preview.texture = load("res://cardbutton.png")
 	$CanvasLayer/Info/ScrollContainer/CardText.text = ""
+	for ac in $CanvasLayer/Info/AttachedCardsList/HBoxContainer.get_children():
+		ac.free()
 
 
 func _restart(id=null):

--- a/Scripts/side.gd
+++ b/Scripts/side.gd
@@ -60,7 +60,7 @@ signal made_turn_choice(choice)
 signal rps(choice)
 signal ready_decided
 
-signal card_info_set(card_num, desc, art_data)
+signal card_info_set(card_num, desc, art_data, attached_cards)
 signal card_info_clear
 
 signal entered_list
@@ -656,7 +656,11 @@ func archive_opponent_mouse_enter():
 func update_info(card_id):
 	var actualCard = all_cards[card_id]
 	if !actualCard.trulyHidden and (is_multiplayer_authority() or !actualCard.faceDown):
-		emit_signal("card_info_set",actualCard.cardNumber,actualCard.full_desc(),actualCard.cardFront)
+		var attached_cards = []
+		for attached_card in actualCard.attached:
+			attached_cards.push_back(attached_card.cardFront)
+			# print(attached_card.cardNumber,attached_card.cardFront)
+		emit_signal("card_info_set",actualCard.cardNumber,actualCard.full_desc(),actualCard.cardFront,attached_cards)
 
 func clear_info():
 	emit_signal("card_info_clear")


### PR DESCRIPTION
Modifies `update_info` to support being provided a list of attached cards.
Examples of a card with many attached cheers and a use case for a card with cheers being obscured by another.
![image](https://github.com/user-attachments/assets/04427b76-b580-40ce-942b-23c795dee94e)
![image](https://github.com/user-attachments/assets/fa089c65-f149-4e8d-b0c7-f8d73a0d86fa)
